### PR TITLE
lua redis.call('get',@key) returns boolean false not nil

### DIFF
--- a/src/NHibernate.Caches.Redis/RedisCache.cs
+++ b/src/NHibernate.Caches.Redis/RedisCache.cs
@@ -23,7 +23,7 @@ namespace NHibernate.Caches.Redis
         private static readonly LuaScript getScript = LuaScript.Prepare(@"
 if redis.call('sismember', @setOfActiveKeysKey, @key) == 1 then
     local result = redis.call('get', @key)
-    if result == nil then
+    if (result==nil or (type(result) == 'boolean' and not result)) then
         redis.call('srem', @setOfActiveKeysKey, @key)
     end
     return result


### PR DESCRIPTION
lua redis.call('get',@key) returns boolean false not nil, when not found (Redis 3.2.0)
As a result srem for :keys was never called.
Fix and test added