### PR TITLE
Add testing compatibility with SQL Server 2014, CacheNamespacePrefix can be set in configuration

### DIFF
--- a/src/NHibernate.Caches.Redis/RedisCache.cs
+++ b/src/NHibernate.Caches.Redis/RedisCache.cs
@@ -12,8 +12,6 @@ namespace NHibernate.Caches.Redis
 {
     public class RedisCache : ICache
     {
-        private const string cacheNamespacePrefix = "NHibernate-Cache:";
-
         private static readonly IInternalLogger log = LoggerProvider.LoggerFor(typeof(RedisCache));
 
         // The acquired locks do not need to be distributed into Redis because
@@ -120,7 +118,7 @@ end
                 RegionName, expiration, lockTimeout, acquireLockTimeout
             );
 
-            CacheNamespace = new RedisNamespace(cacheNamespacePrefix + RegionName);
+            CacheNamespace = new RedisNamespace(options.CacheNamespacePrefix + RegionName);
         }
 
         public long NextTimestamp()

--- a/src/NHibernate.Caches.Redis/RedisCacheProviderOptions.cs
+++ b/src/NHibernate.Caches.Redis/RedisCacheProviderOptions.cs
@@ -58,7 +58,14 @@ namespace NHibernate.Caches.Redis
         /// </summary>
         public IEnumerable<RedisCacheConfiguration> CacheConfigurations { get; set; }
 
-        public RedisCacheProviderOptions()
+		/// <summary>
+		/// Cache namespace prefix for Redis
+		/// Defaults to "NHibernate-Cache:"
+		/// If NHibernate.Caches.Redis is the only user of given Redis Database, can be set to NULL to reduce key length
+		/// </summary>
+		public string CacheNamespacePrefix { get; set; } = "NHibernate-Cache:";
+
+	    public RedisCacheProviderOptions()
         {
             Serializer = new NetDataContractCacheSerializer();
             AcquireLockRetryStrategy = new ExponentialBackoffWithJitterAcquireLockRetryStrategy();

--- a/tests/NHibernate.Caches.Redis.Tests/IntegrationTestBase.cs
+++ b/tests/NHibernate.Caches.Redis.Tests/IntegrationTestBase.cs
@@ -81,11 +81,11 @@ namespace NHibernate.Caches.Redis.Tests
 
         private void CreateDatabase(SqlConnection connection)
         {
-            // Minimum DB size is 2MB on <= SQL 2008 R2 and 3MB >= SQL 2012.
+            // Minimum DB size is 2MB on <= SQL 2008 R2, 3MB on SQL 2012 and 5MB >= SQL 2014.
             var create = @"create database [{0}] on PRIMARY";
-            create += @" ( name = N'{0}', filename = N'{1}', size = 3072KB, maxsize = unlimited, filegrowth = 10% ) ";
+            create += @" ( name = N'{0}', filename = N'{1}', size = 5MB, maxsize = unlimited, filegrowth = 10% ) ";
             create += @" log on ";
-            create += @" ( name = N'{0}_log', filename = N'{2}', size = 1024KB, maxsize = 2048GB, filegrowth = 10% ) ";
+            create += @" ( name = N'{0}_log', filename = N'{2}', size = 1MB, maxsize = 2048GB, filegrowth = 10% ) ";
 
             using (var cmd = connection.CreateCommand())
             {


### PR DESCRIPTION
SQL Server 2014 requires at least 5MB database file.

CacheNamespacePrefix can be set in configuration.
