### PR TITLE
Add flags to disable SetOfActiveKeys.

### DIFF
--- a/src/NHibernate.Caches.Redis/RedisCacheConfiguration.cs
+++ b/src/NHibernate.Caches.Redis/RedisCacheConfiguration.cs
@@ -13,8 +13,29 @@ namespace NHibernate.Caches.Redis
         public static readonly TimeSpan DefaultLockTimeout = TimeSpan.FromSeconds(30);
         public static readonly TimeSpan DefaultAcquireLockTimeout = DefaultLockTimeout;
         public static readonly TimeSpan NoSlidingExpiration = TimeSpan.Zero;
+        public static readonly bool DefaultSetOfActiveKeysEnabled = true;
 
         public string RegionName { get; private set; }
+
+        /// <summary>
+        /// Gets or sets whether or not to keep a list of active keys in the
+        /// cache. Defaults to true.
+        ///
+        /// By default, all cache keys are stored in a Redis set. This set is
+        /// used to invalidate any non-expired values in the cache when the
+        /// Clear() method is called.
+        ///
+        /// The keys in the set are only ever removed in two situations:
+        ///     1) the Clear() method is called, or
+        ///     2) a cached value is requested after it has expired.
+        ///
+        /// If your cache experiences a lot of churn and you never explicitly
+        /// clear the cache, the set of active keys will eventually fill up
+        /// the entire cache. Disabling the set of active keys functionality
+        /// can help in this situation, but you will not be able to use the
+        /// Clear() method to invalidate your cache.
+        /// </summary>
+        public bool SetOfActiveKeysEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets the duration that the item remains in the cache.
@@ -62,6 +83,7 @@ namespace NHibernate.Caches.Redis
             this.SlidingExpiration = NoSlidingExpiration;
             this.LockTimeout = DefaultLockTimeout;
             this.AcquireLockTimeout = DefaultAcquireLockTimeout;
+            this.SetOfActiveKeysEnabled = DefaultSetOfActiveKeysEnabled;
         }
 
         /// <summary>
@@ -76,6 +98,7 @@ namespace NHibernate.Caches.Redis
             SlidingExpiration = other.SlidingExpiration;
             LockTimeout = other.LockTimeout;
             AcquireLockTimeout = other.AcquireLockTimeout;
+            SetOfActiveKeysEnabled = other.SetOfActiveKeysEnabled;
         }
 
         internal static RedisCacheConfiguration FromPropertiesOrDefaults(string regionName, IDictionary<string, string> properties)

--- a/src/NHibernate.Caches.Redis/RedisCacheConfiguration.cs
+++ b/src/NHibernate.Caches.Redis/RedisCacheConfiguration.cs
@@ -13,7 +13,11 @@ namespace NHibernate.Caches.Redis
         public static readonly TimeSpan DefaultLockTimeout = TimeSpan.FromSeconds(30);
         public static readonly TimeSpan DefaultAcquireLockTimeout = DefaultLockTimeout;
         public static readonly TimeSpan NoSlidingExpiration = TimeSpan.Zero;
-        public static readonly bool DefaultSetOfActiveKeysEnabled = true;
+
+        /// <summary>
+        /// Sets the default value for the SetOfActiveKeysEnabled property.
+        /// </summary>
+        public static bool DefaultSetOfActiveKeysEnabled { get; set; }
 
         public string RegionName { get; private set; }
 
@@ -71,6 +75,11 @@ namespace NHibernate.Caches.Redis
         /// for the item. By default, this is the same as the lock timeout.
         /// </summary>
         public TimeSpan AcquireLockTimeout { get; set; }
+
+        static RedisCacheConfiguration()
+        {
+            DefaultSetOfActiveKeysEnabled = true;
+        }
 
         /// <summary>
         /// Default constructor.

--- a/src/NHibernate.Caches.Redis/RedisCacheException.cs
+++ b/src/NHibernate.Caches.Redis/RedisCacheException.cs
@@ -35,6 +35,12 @@ namespace NHibernate.Caches.Redis
 
         }
 
+        public RedisCacheException(string regionName, string message)
+            : this(message)
+        {
+            this.RegionName = regionName;
+        }
+
         public RedisCacheException(string regionName, string message, Exception innerException)
             : this(message, innerException)
         {


### PR DESCRIPTION
We ran into an issue where our entire Redis cache (26 GB) was used up by the "NHibernate-Cache:NHibernate.Cache.StandardQueryCache:keys" set.

This PR adds a `RedisCacheConfiguration.SetOfActiveKeysEnabled` flag that allows you to disable the SetOfActiveKeys set ("*:keys" in Redis) for a specific region. It also adds a static `RedisCacheConfiguration.DefaultSetOfActiveKeysEnabled` flag that can disable the set for all regions.

If you choose to disable the set of active keys, the `RedisCache.Clear()` method will throw an exception if you call it.

In order to maintain backwards compatibility, I left the set enabled by default.

This may also be useful for #21.
