### PR TITLE
Added NH5 support while retaining compatibility with previous versions of NH

### DIFF
--- a/NHibernate.Caches.Redis.sln
+++ b/NHibernate.Caches.Redis.sln
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sample", "sample", "{174608
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.Caches.Redis.Sample", "sample\NHibernate.Caches.Redis.Sample\NHibernate.Caches.Redis.Sample.csproj", "{3BA51CF9-7DCC-4265-A043-F83284D1942A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.Caches.Redis.NH5.Tests", "tests\NHibernate.Caches.Redis.NH5.Tests\NHibernate.Caches.Redis.NH5.Tests.csproj", "{A4D58903-0A5F-41F1-A81B-C41EDAAA8696}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{3BA51CF9-7DCC-4265-A043-F83284D1942A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BA51CF9-7DCC-4265-A043-F83284D1942A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BA51CF9-7DCC-4265-A043-F83284D1942A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4D58903-0A5F-41F1-A81B-C41EDAAA8696}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4D58903-0A5F-41F1-A81B-C41EDAAA8696}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4D58903-0A5F-41F1-A81B-C41EDAAA8696}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4D58903-0A5F-41F1-A81B-C41EDAAA8696}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -54,5 +60,6 @@ Global
 		{1B50164C-DB00-4109-A0D4-E2868ABFEDAF} = {F5128A75-1A1D-4585-BB4E-A9E55D12D03C}
 		{A067C7D2-CF09-4F24-9848-5CE10DC48438} = {F0732F96-D774-44A7-B51A-54AC1A278F99}
 		{3BA51CF9-7DCC-4265-A043-F83284D1942A} = {174608AE-6E0A-4774-9DB9-46BC5E3B3C78}
+		{A4D58903-0A5F-41F1-A81B-C41EDAAA8696} = {F0732F96-D774-44A7-B51A-54AC1A278F99}
 	EndGlobalSection
 EndGlobal

--- a/build/build.proj
+++ b/build/build.proj
@@ -33,9 +33,10 @@
     <Target Name="_ExecTests">
         <ItemGroup>
             <TestItems Include="$(TestsRoot)\NHibernate.Caches.Redis.Tests\bin\Release\NHibernate.Caches.Redis.Tests.dll" />
+            <TestItems Include="$(TestsRoot)\NHibernate.Caches.Redis.NH5.Tests\bin\Release\NHibernate.Caches.Redis.NH5.Tests.dll" />
         </ItemGroup>
     
-        <xunit Assembly="@(TestItems)" />
+        <xunit Assemblies="@(TestItems)" />
     </Target>
 
     <Target Name="_StartRedis">

--- a/src/NHibernate.Caches.Redis/Properties/AssemblyInfo.cs
+++ b/src/NHibernate.Caches.Redis/Properties/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("An NHibernate caching provider for Redis.")]
 [assembly: Guid("c3db6972-73e3-4a08-8a79-99e6c29d1d25")]
 [assembly: InternalsVisibleTo("NHibernate.Caches.Redis.Tests")]
+[assembly: InternalsVisibleTo("NHibernate.Caches.Redis.NH5.Tests")]

--- a/tests/NHibernate.Caches.Redis.NH5.Tests/IntegrationAsyncTests.cs
+++ b/tests/NHibernate.Caches.Redis.NH5.Tests/IntegrationAsyncTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NHibernate.Caches.Redis.Tests
+{
+
+    public class IntegrationAsyncTests : IntegrationTestBase
+    {
+        [Fact]
+        async Task Entity_cache()
+        {
+            using (var sf = CreateSessionFactory())
+            {
+                object personId = null;
+
+                await UsingSessionAsync(sf, async session =>
+                {
+                    personId = await session.SaveAsync(new Person("Foo", 1));
+
+                    Assert.Equal(0, sf.Statistics.SecondLevelCacheHitCount);
+                    Assert.Equal(0, sf.Statistics.SecondLevelCacheMissCount);
+                    Assert.Equal(0, sf.Statistics.SecondLevelCachePutCount);
+                });
+
+                sf.Statistics.Clear();
+
+                await UsingSessionAsync(sf, async session =>
+                {
+                    await session.GetAsync<Person>(personId);
+
+                    Assert.Equal(1, sf.Statistics.SecondLevelCacheMissCount);
+                    Assert.Equal(1, sf.Statistics.SecondLevelCachePutCount);
+                });
+
+                sf.Statistics.Clear();
+
+                await UsingSessionAsync(sf, async session =>
+                {
+                    await session.GetAsync<Person>(personId);
+
+                    Assert.Equal(1, sf.Statistics.SecondLevelCacheHitCount);
+                    Assert.Equal(0, sf.Statistics.SecondLevelCacheMissCount);
+                    Assert.Equal(0, sf.Statistics.SecondLevelCachePutCount);
+
+                });
+            }
+        }
+
+        [Fact]
+        async Task SessionFactory_Dispose_should_not_clear_cache()
+        {
+            using (var sf = CreateSessionFactory())
+            {
+                await UsingSessionAsync(sf, async session =>
+                {
+                    await session.SaveAsync(new Person("Foo", 10));
+                });
+
+                await UsingSessionAsync(sf, async session =>
+                {
+                    await session.QueryOver<Person>()
+                        .Cacheable()
+                        .ListAsync();
+
+                    Assert.Equal(1, sf.Statistics.QueryCacheMissCount);
+                    Assert.Equal(1, sf.Statistics.SecondLevelCachePutCount);
+                    Assert.Equal(1, sf.Statistics.QueryCachePutCount);
+                });
+            }
+
+            using (var sf = CreateSessionFactory())
+            {
+                await UsingSessionAsync(sf, async session =>
+                {
+                    await session.QueryOver<Person>()
+                        .Cacheable()
+                        .ListAsync();
+
+                    Assert.Equal(1, sf.Statistics.SecondLevelCacheHitCount);
+                    Assert.Equal(1, sf.Statistics.QueryCacheHitCount);
+                    Assert.Equal(0, sf.Statistics.SecondLevelCachePutCount);
+                    Assert.Equal(0, sf.Statistics.QueryCachePutCount);
+                });
+            }
+        }
+
+        async Task UsingSessionAsync(ISessionFactory sessionFactory, Func<ISession, Task> action)
+        {
+            using (var session = sessionFactory.OpenSession())
+            using (var transaction = session.BeginTransaction())
+            {
+                await action(session);
+                await transaction.CommitAsync();
+            }
+        }
+    }
+}

--- a/tests/NHibernate.Caches.Redis.NH5.Tests/NHibernate.Caches.Redis.NH5.Tests.csproj
+++ b/tests/NHibernate.Caches.Redis.NH5.Tests/NHibernate.Caches.Redis.NH5.Tests.csproj
@@ -1,0 +1,134 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A4D58903-0A5F-41F1-A81B-C41EDAAA8696}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NHibernate.Caches.Redis.NH5.Tests</RootNamespace>
+    <AssemblyName>NHibernate.Caches.Redis.NH5.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentNHibernate">
+      <HintPath>..\..\packages\FluentNHibernate.1.3.0.733\lib\FluentNHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Iesi.Collections.4.0.0.4000\lib\net40\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Remotion.Linq.EagerFetching, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="StackExchange.Redis, Version=1.0.481.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\StackExchange.Redis.1.0.481\lib\net45\StackExchange.Redis.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NHibernate.Caches.Redis.Tests\DoNotRetryAcquireLockRetryStrategy.cs">
+      <Link>DoNotRetryAcquireLockRetryStrategy.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.Caches.Redis.Tests\IntegrationTestBase.cs">
+      <Link>IntegrationTestBase.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.Caches.Redis.Tests\IntegrationTests.cs">
+      <Link>IntegrationTests.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.Caches.Redis.Tests\PerformanceTests.cs">
+      <Link>PerformanceTests.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.Caches.Redis.Tests\Person.cs">
+      <Link>Person.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.Caches.Redis.Tests\PersonMapping.cs">
+      <Link>PersonMapping.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.Caches.Redis.Tests\RedisCacheProviderOptionsTests.cs">
+      <Link>RedisCacheProviderOptionsTests.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.Caches.Redis.Tests\RedisCacheTests.cs">
+      <Link>RedisCacheTests.cs</Link>
+    </Compile>
+    <Compile Include="IntegrationAsyncTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.Caches.Redis.Tests\RedisTest.cs">
+      <Link>RedisTest.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NHibernate.Caches.Redis\NHibernate.Caches.Redis.csproj">
+      <Project>{1B50164C-DB00-4109-A0D4-E2868ABFEDAF}</Project>
+      <Name>NHibernate.Caches.Redis</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/NHibernate.Caches.Redis.NH5.Tests/Properties/AssemblyInfo.cs
+++ b/tests/NHibernate.Caches.Redis.NH5.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NHibernate.Caches.Redis.NH5.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NHibernate.Caches.Redis.NH5.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a4d58903-0a5f-41f1-a81b-c41edaaa8696")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/NHibernate.Caches.Redis.NH5.Tests/app.config
+++ b/tests/NHibernate.Caches.Redis.NH5.Tests/app.config
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.9.0" newVersion="2.6.9.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.9.0" newVersion="2.6.9.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>

--- a/tests/NHibernate.Caches.Redis.NH5.Tests/packages.config
+++ b/tests/NHibernate.Caches.Redis.NH5.Tests/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
+  <package id="FluentNHibernate" version="1.3.0.733" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.0.4000" targetFramework="net461" />
+  <package id="NHibernate" version="5.0.0" targetFramework="net461" />
+  <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
+  <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
+  <package id="StackExchange.Redis" version="1.0.481" targetFramework="net461" />
+  <package id="xunit" version="1.9.2" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
Based on the discussion at https://github.com/TheCloudlessSky/NHibernate.Caches.Redis/pull/31, in order to keep compatibity with previous versions of NHibernate, the only change needed to be made is adding the new async methods to the cache. 

This allows the user to reference and use:
- a previous version of NH (the new methods will not be part of the ICache interface contract and they are just... hmm... let's say "hanging in the air" ;) )
- NH5 (the new methods are now part of the ICache interface contract)

I've also marked these methods as virtual in order to let the user override them if needed.

The solution compiles fine, but I haven't tested it with a previous version of NH (as no functional changes have been made, it should work just like before). NH5 seems to be quite happy ;)

Many thanks @TheCloudlessSky for creating this lib and @gliljas for the NH5 support!